### PR TITLE
Fix iteration

### DIFF
--- a/src/count/data.py
+++ b/src/count/data.py
@@ -18,13 +18,15 @@ from allennlp.data.tokenizers import Token, WhitespaceTokenizer
 from allennlp.data.tokenizers.sentence_splitter import SpacySentenceSplitter
 from allennlp.data.tokenizers.tokenizer import Tokenizer
 
+import config
+
 # Local
 from tokenizer import WikiTextTokenizer
-import config
 
 logger = logging.getLogger(__name__)
 
 
+@DatasetReader.register("wikitext-reader")
 class WikiTextReader(DatasetReader):
     """
     Creates `Instances` suitable for use in predicting a single next token using a language

--- a/src/count/data.py
+++ b/src/count/data.py
@@ -62,7 +62,7 @@ class WikiTextReader(DatasetReader):
 
     def _read(self, file_path: str) -> Iterable[Instance]:
         logger.info(f"Loading data from {file_path}")
-        with open(file_path, "r",encoding='utf8') as f:
+        with open(file_path, "r", encoding="utf8") as f:
             for line in f:
                 if line.strip() and line.strip()[0] != "=":
                     yield from self.generate_instances(line)
@@ -106,9 +106,13 @@ class WikiTextReader(DatasetReader):
             Instance containing a `tokens` field and a `target` field.
         """
 
-        input_field = TextField(tokens, self._token_indexers)
+        input_field = TextField(tokens)
         fields: Dict[str, Field] = {"tokens": input_field}
         return Instance(fields)
+
+    def apply_token_indexers(self, instance):
+        """Adds a token indexer to the instance. Automatically called by AllenNLP."""
+        instance["tokens"].token_indexers = self._token_indexers
 
 
 if __name__ == "__main__":
@@ -116,7 +120,11 @@ if __name__ == "__main__":
         tokenizer_path=config.TOKENIZER,
         add_special_tokens=True,
     )
-    reader = WikiTextReader(context=10, tokenizer=wiki_tokenizer)
+    reader = WikiTextReader(
+        context=10,
+        tokenizer=wiki_tokenizer,
+        token_indexers={"tokens": SingleIdTokenIndexer(namespace="tokens")},
+    )
     dataset = reader.read(config.WIKI_RAW_DIR / "wiki.train.raw")
     for i in islice(dataset, 4):
         print(i)

--- a/src/count/data.py
+++ b/src/count/data.py
@@ -62,12 +62,16 @@ class WikiTextReader(DatasetReader):
         }
         self._context = context
 
-    def _read(self, file_path: str) -> Iterable[Instance]:
+    def _single_process_read(self, file_path: str) -> Iterable[Instance]:
         logger.info(f"Loading data from {file_path}")
         with open(file_path, "r", encoding="utf8") as f:
             for line in f:
                 if line.strip() and line.strip()[0] != "=":
                     yield from self.generate_instances(line)
+
+    def _read(self, file_path: str) -> Iterable[Instance]:
+        shards = self._single_process_read(file_path)
+        yield from self.shard_iterable(shards)
 
     def generate_instances(self, text: str) -> Iterable[Instance]:
         """Generates instances of a certain context size given the available text

--- a/src/count/main.py
+++ b/src/count/main.py
@@ -1,7 +1,6 @@
 # Utilities
 import torch
 import numpy
-from itertools import islice
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 from itertools import islice
 
@@ -31,8 +30,8 @@ from model import LanguageModel
 if __name__ == "__main__":
     # Build reader
     # ============
-    reader = WikiTextReader(100)
-    instances = list(islice(reader.read(config.WIKI_RAW_DIR / "wiki.train.raw"), 100))
+    reader = WikiTextReader(100, max_instances=100)
+    instances = list(reader.read(config.WIKI_RAW_DIR / "wiki.train.raw"))
 
     # Read vocabulary from vocabulary directory
     # =========================================
@@ -60,6 +59,7 @@ if __name__ == "__main__":
         data_loader=data_loader,
         num_epochs=5,
         optimizer=torch.optim.Adam(model.parameters()),
+        cuda_device=config.DEVICE_1,
     )
 
     # Run training

--- a/src/count/main.py
+++ b/src/count/main.py
@@ -38,10 +38,12 @@ if __name__ == "__main__":
     # Build reader
     # ============
     reader = WikiTextReader(
-        context=50,
+        context=10,
         tokenizer=wiki_tokenizer,
         token_indexers={"tokens": SingleIdTokenIndexer(namespace="tokens")},
-        max_instances=100,
+        manual_distributed_sharding=True,
+        manual_multiprocess_sharding=True,
+        max_instances=30_000,
     )
 
     # Read vocabulary from vocabulary directory
@@ -55,25 +57,22 @@ if __name__ == "__main__":
 
     # Setup model and training
     # ========================
-    # data_loader = SimpleDataLoader(
-    #     reader=readder,
-    #     data_path=config.WIKI_RAW_DIR / "wiki.train.raw",
-    #     batch_size=4,
-    #     vocab=vocab,
-    #     shuffle=True,
-    # )
     train_data_loader = MultiProcessDataLoader(
         reader=reader,
         data_path=config.WIKI_RAW_DIR / "wiki.train.raw",
-        batch_size=16,
+        batch_size=64,
         shuffle=True,
+        max_instances_in_memory=None,
+        num_workers=4,
     )
     train_data_loader.index_with(vocab)
     val_data_loader = MultiProcessDataLoader(
         reader=reader,
         data_path=config.WIKI_RAW_DIR / "wiki.valid.raw",
-        batch_size=16,
+        batch_size=64,
         shuffle=False,
+        max_instances_in_memory=None,
+        num_workers=4,
     )
     val_data_loader.index_with(vocab)
 

--- a/src/count/model.py
+++ b/src/count/model.py
@@ -75,10 +75,10 @@ class LanguageModel(Model):
     ) -> Dict[str, torch.Tensor]:
 
         # shape (batch_size, timesteps)
-        token_ids = tokens['tokens']['tokens']
+        token_ids = tokens["tokens"]["tokens"]
 
         # get source and targets from tokens
-        source = token_ids[:, 0:-1]
+        source = token_ids[:, :-1]
         target = token_ids[:, 1:]
 
         # do embedding stuff here
@@ -109,7 +109,7 @@ class LanguageModel(Model):
         # calculates the perplexity for the model
         self.metric(loss)
 
-        return {"logits": logits, "loss": loss, 'probs': probs}
+        return {"logits": logits, "loss": loss, "probs": probs}
 
     def make_output_human_readable(
         self, output_dict: Dict[str, torch.Tensor]

--- a/src/count/model.py
+++ b/src/count/model.py
@@ -5,6 +5,7 @@ import numpy
 
 # Utilities
 import torch
+from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 
 # AllenNLP
 from allennlp.data import Instance, Token, Vocabulary

--- a/src/count/model.py
+++ b/src/count/model.py
@@ -1,34 +1,30 @@
 # STL
 from typing import Dict
 
+import numpy
 # Utilities
 import torch
-import numpy
-from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
-
 # AllenNLP
 from allennlp.data import Instance, Token, Vocabulary
 from allennlp.data.data_loaders import SimpleDataLoader
-from allennlp.data.fields import TextField, LabelField
+from allennlp.data.fields import LabelField, TextField
 from allennlp.data.fields.text_field import TextFieldTensors
-from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
-
+from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
 # Models
 from allennlp.models import Model
-
+from allennlp.modules import Embedding, TextFieldEmbedder
+# Layers
+from allennlp.modules.attention import Attention
+from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
+from allennlp.modules.transformer import TransformerLayer
+from allennlp.nn.activations import Activation
+from allennlp.nn.util import (get_text_field_mask,
+                              sequence_cross_entropy_with_logits)
 # Inference
 from allennlp.predictors.predictor import Predictor
-
 # Training
 from allennlp.training.metrics import Perplexity
 from allennlp.training.trainer import GradientDescentTrainer, Trainer
-
-# Layers
-from allennlp.modules.attention import Attention
-from allennlp.modules.transformer import TransformerLayer
-from allennlp.modules import Embedding, TextFieldEmbedder
-from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
-from allennlp.nn.activations import Activation
 
 # Local
 from data import WikiTextReader


### PR DESCRIPTION
Fixed the iteration problem, now we can load in a fixed number of instances at a time to prevent memory crashes.

- It's slightly faster to load them all in at once, but we obviously don't have that luxury sometimes.
- Also, I added support for multiple `DataLoader` workers, which should help with loading speed if it's ever slow. I find that it's not a limiting factor if we use 4 workers, 8 might be better though.