### PR TITLE
Normalize perplexity

### DIFF
--- a/src/count/config.py
+++ b/src/count/config.py
@@ -27,7 +27,8 @@ CLS = "[CLS]"
 SEP = "[SEP]"
 
 # Constants
-DIF_TOKENIZERS_RATIO = 101_425_671 / 101_425_671
+# Currently the denominator is arbitrary. It should be the total number of tokens from the new tokenizer.
+DIF_TOKENIZERS_RATIO = 101_425_671 / 111_568_238
 
 
 # Hyper-parameters

--- a/src/count/config.py
+++ b/src/count/config.py
@@ -5,22 +5,31 @@ Hyperparameters should go in the AllenNLP config file, whenever we manage to get
 
 from pathlib import Path
 import torch
+import os
 
 # Project root
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = str(Path(__file__).resolve().parents[2])
 
 # Paths
-TOKENIZER = ROOT / "unigram-tokenizer.json"
-DATA_DIR = ROOT / "data"
-VOCAB_DIR = ROOT / "data" / "vocab"
-WIKI_RAW_DIR = ROOT / "data" / "wikitext-103-raw"
+TOKENIZER = os.path.join(ROOT, "unigram-tokenizer.json")
+DATA_DIR = os.path.join(ROOT, "data")
+VOCAB_DIR = os.path.join(ROOT, "data", "vocab")
+WIKI_RAW_DIR = os.path.join(ROOT, "data", "wikitext-103-raw")
 
 # Parameters
 VOCAB_SIZE = 30_000
-DEVICE_1 = "cuda" if torch.cuda.is_available() else "cpu"
+DEVICE_1 = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 # Special tokens
 PAD = "[PAD]"
 UNK = "[UNK]"
 CLS = "[CLS]"
 SEP = "[SEP]"
+
+# Constants
+DIF_TOKENIZERS_RATIO = 101_425_671 / 101_425_671
+
+
+# Hyper-parameters
+CONTEXT_WINDOW = 100
+BATCH_SIZE = 4

--- a/src/count/config.py
+++ b/src/count/config.py
@@ -28,6 +28,7 @@ SEP = "[SEP]"
 
 # Constants
 # Currently the denominator is arbitrary. It should be the total number of tokens from the new tokenizer.
+# Support for subset training has yet to be added. 
 DIF_TOKENIZERS_RATIO = 101_425_671 / 111_568_238
 
 

--- a/src/count/data.py
+++ b/src/count/data.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from itertools import islice
 from typing import Dict, Iterable
 
@@ -45,11 +46,11 @@ class WikiTextReader(DatasetReader):
     """
 
     def __init__(
-        self,
-        context: int,
-        tokenizer: Tokenizer = None,
-        token_indexers: Dict[str, TokenIndexer] = None,
-        **kwargs,
+            self,
+            context: int,
+            tokenizer: Tokenizer = None,
+            token_indexers: Dict[str, TokenIndexer] = None,
+            **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self._sentence_splitter = SpacySentenceSplitter(rule_based=True)
@@ -62,7 +63,7 @@ class WikiTextReader(DatasetReader):
 
     def _read(self, file_path: str) -> Iterable[Instance]:
         logger.info(f"Loading data from {file_path}")
-        with open(file_path, "r",encoding='utf8') as f:
+        with open(file_path, "r", encoding='utf8') as f:
             for line in f:
                 if line.strip() and line.strip()[0] != "=":
                     yield from self.generate_instances(line)
@@ -87,11 +88,11 @@ class WikiTextReader(DatasetReader):
             tokens = self._tokenizer.tokenize(sent)
             for start in range(len(tokens) - self._context):
                 width = start + self._context
-                yield self.text_to_instance(tokens[start : width + 1])
+                yield self.text_to_instance(tokens[start: width + 1])
 
     def text_to_instance(
-        self,
-        tokens: Iterable[Token],
+            self,
+            tokens: Iterable[Token],
     ) -> Instance:
         """Converts a list of `Token`s into an `Instance`
 
@@ -117,6 +118,6 @@ if __name__ == "__main__":
         add_special_tokens=True,
     )
     reader = WikiTextReader(context=10, tokenizer=wiki_tokenizer)
-    dataset = reader.read(config.WIKI_RAW_DIR / "wiki.train.raw")
+    dataset = reader.read(os.path.join(config.WIKI_RAW_DIR, "wiki.train.raw"))
     for i in islice(dataset, 4):
         print(i)

--- a/src/count/data.py
+++ b/src/count/data.py
@@ -26,6 +26,7 @@ import config
 logger = logging.getLogger(__name__)
 
 
+@DatasetReader.register("wikitext-reader")
 class WikiTextReader(DatasetReader):
     """
     Creates `Instances` suitable for use in predicting a single next token using a language
@@ -61,7 +62,7 @@ class WikiTextReader(DatasetReader):
         }
         self._context = context
 
-    def _read(self, file_path: str) -> Iterable[Instance]:
+    def _single_process_read(self, file_path: str) -> Iterable[Instance]:
         logger.info(f"Loading data from {file_path}")
         with open(file_path, "r", encoding='utf8') as f:
             for line in f:
@@ -117,7 +118,11 @@ if __name__ == "__main__":
         tokenizer_path=config.TOKENIZER,
         add_special_tokens=True,
     )
-    reader = WikiTextReader(context=10, tokenizer=wiki_tokenizer)
+    reader = WikiTextReader(
+        context=10,
+        tokenizer=wiki_tokenizer,
+        token_indexers={"tokens": SingleIdTokenIndexer(namespace="tokens")},
+    )
     dataset = reader.read(os.path.join(config.WIKI_RAW_DIR, "wiki.train.raw"))
     for i in islice(dataset, 4):
         print(i)

--- a/src/count/data.py
+++ b/src/count/data.py
@@ -64,10 +64,14 @@ class WikiTextReader(DatasetReader):
 
     def _single_process_read(self, file_path: str) -> Iterable[Instance]:
         logger.info(f"Loading data from {file_path}")
-        with open(file_path, "r", encoding='utf8') as f:
+        with open(file_path, "r", encoding="utf8") as f:
             for line in f:
                 if line.strip() and line.strip()[0] != "=":
                     yield from self.generate_instances(line)
+
+    def _read(self, file_path: str) -> Iterable[Instance]:
+        shards = self._single_process_read(file_path)
+        yield from self.shard_iterable(shards)
 
     def generate_instances(self, text: str) -> Iterable[Instance]:
         """Generates instances of a certain context size given the available text
@@ -92,8 +96,8 @@ class WikiTextReader(DatasetReader):
                 yield self.text_to_instance(tokens[start: width + 1])
 
     def text_to_instance(
-            self,
-            tokens: Iterable[Token],
+        self,
+        tokens: Iterable[Token],
     ) -> Instance:
         """Converts a list of `Token`s into an `Instance`
 
@@ -108,9 +112,13 @@ class WikiTextReader(DatasetReader):
             Instance containing a `tokens` field and a `target` field.
         """
 
-        input_field = TextField(tokens, self._token_indexers)
+        input_field = TextField(tokens)
         fields: Dict[str, Field] = {"tokens": input_field}
         return Instance(fields)
+
+    def apply_token_indexers(self, instance):
+        """Adds a token indexer to the instance. Automatically called by AllenNLP."""
+        instance["tokens"].token_indexers = self._token_indexers
 
 
 if __name__ == "__main__":

--- a/src/count/main.py
+++ b/src/count/main.py
@@ -2,6 +2,7 @@
 import torch
 import numpy
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
+import os
 
 # AllenNLP
 from allennlp.data import Instance, Token, Vocabulary
@@ -29,8 +30,8 @@ from model import LanguageModel
 if __name__ == "__main__":
     # Build reader
     # ============
-    reader = WikiTextReader(100)
-    instances = reader.read(config.WIKI_RAW_DIR / "wiki.train.raw")
+    reader = WikiTextReader(config.CONTEXT_WINDOW)
+    instances = reader.read(os.path.join(config.WIKI_RAW_DIR, "wiki.train.raw"))
 
     # Read vocabulary from vocabulary directory
     # =========================================
@@ -43,7 +44,7 @@ if __name__ == "__main__":
 
     # Setup model and training
     # ========================
-    data_loader = SimpleDataLoader(instances, batch_size=4, vocab=vocab)
+    data_loader = SimpleDataLoader(instances, batch_size=config.BATCH_SIZE, vocab=vocab)
 
     model = LanguageModel(
         vocab=vocab,
@@ -54,7 +55,7 @@ if __name__ == "__main__":
     )
 
     trainer = GradientDescentTrainer(
-        model=model.cuda(),
+        model=model.to(config.DEVICE_1),
         data_loader=data_loader,
         num_epochs=5,
         optimizer=torch.optim.Adam(model.parameters()),

--- a/src/count/model.py
+++ b/src/count/model.py
@@ -76,9 +76,10 @@ class LanguageModel(Model):
         self.metric = Perplexity()
 
     def forward(
-            self,
-            tokens: TextFieldTensors,
+        self,
+        tokens: TextFieldTensors,
     ) -> Dict[str, torch.Tensor]:
+
         # shape (batch_size, timesteps)
         token_ids = tokens["tokens"]["tokens"]
 

--- a/src/count/model.py
+++ b/src/count/model.py
@@ -1,20 +1,22 @@
 # STL
 from typing import Dict
 
+import numpy
+
 # Utilities
 import torch
-import numpy
 from allennlp.nn.util import get_text_field_mask, sequence_cross_entropy_with_logits
 
 # AllenNLP
 from allennlp.data import Instance, Token, Vocabulary
 from allennlp.data.data_loaders import SimpleDataLoader
-from allennlp.data.fields import TextField, LabelField
+from allennlp.data.fields import LabelField, TextField
 from allennlp.data.fields.text_field import TextFieldTensors
-from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
+from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
 
 # Models
 from allennlp.models import Model
+from allennlp.modules import Embedding, TextFieldEmbedder
 
 # Inference
 from allennlp.predictors.predictor import Predictor
@@ -25,7 +27,7 @@ from allennlp.training.trainer import GradientDescentTrainer, Trainer
 
 # Layers
 from allennlp.modules.attention import Attention
-from allennlp.modules.transformer import TransformerLayer
+from allennlp.modules.transformer import TransformerLayer, TransformerStack
 from allennlp.modules import Embedding, TextFieldEmbedder
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.nn.activations import Activation
@@ -38,27 +40,27 @@ import config
 @Model.register("language-model")
 class LanguageModel(Model):
     def __init__(
-            self,
-            vocab: Vocabulary,
-            embedder: TextFieldEmbedder,
-            hidden_size: int,
-            intermediate_size: int,
-            num_attention_heads: int,
-            att_dropout: float = 0.2,
-            hidden_dropout: float = 0.2,
-            activation: str = "relu",
-            cross_attention: bool = False,
+        self,
+        vocab: Vocabulary,
+        embedder: TextFieldEmbedder,
+        hidden_size: int,
+        intermediate_size: int,
+        num_attention_heads: int,
+        att_dropout: float = 0.2,
+        hidden_dropout: float = 0.2,
+        activation: str = "relu",
+        cross_attention: bool = False,
     ) -> None:
         super().__init__(vocab)
 
         self.embedder = embedder
         self.activation = Activation.by_name(activation)()
         # question: what is intermediate size?
-        self.transformer = TransformerLayer(
+        self.transformer = TransformerStack(
+            num_hidden_layers=4,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             num_attention_heads=num_attention_heads,
-            attention_dropout=att_dropout,
             hidden_dropout=hidden_dropout,
             activation=self.activation,
             add_cross_attention=cross_attention,
@@ -81,7 +83,7 @@ class LanguageModel(Model):
         token_ids = tokens["tokens"]["tokens"]
 
         # get source and targets from tokens
-        source = token_ids[:, 0:-1]
+        source = token_ids[:, :-1]
         target = token_ids[:, 1:]
 
         # do embedding stuff here
@@ -106,9 +108,11 @@ class LanguageModel(Model):
         preds = logits.reshape(-1, self.vocab_size)
         target = target.reshape(-1)
 
-        # need to pass pad idx so we can ignore this, unsure how to achieve this in AllenNLP
-        temp = torch.nn.functional.cross_entropy(preds, target, reduction='sum')
+        PAD_IDX = self.vocab.get_token_index(config.PAD)
+
+        temp = torch.nn.functional.cross_entropy(preds, target, ignore_index=PAD_IDX, reduction='sum')
         loss = temp / self.normalizer
+
 
         new_normalized = temp / (self.normalizer * self.dif_tokenizers_ratio)
 
@@ -118,7 +122,7 @@ class LanguageModel(Model):
         return {"logits": logits, "loss": loss, "probs": probs}
 
     def make_output_human_readable(
-            self, output_dict: Dict[str, torch.Tensor]
+        self, output_dict: Dict[str, torch.Tensor]
     ) -> Dict[str, torch.Tensor]:
         """Takes logits from `forward` and computes the corresponding label
 
@@ -131,10 +135,10 @@ class LanguageModel(Model):
         Dict[str, torch.Tensor]:
             Same as input dictionary, but with another key `label` indicating the predicted label
         """
-        # Take the logits from the forward pass, and compute the label IDs for maximum values
+        # Take the logits from the forward pass, and compute the label
+        # IDs for maximum values
         logits = output_dict["logits"].cpu().data.numpy()
         predicted_id: numpy.ndarray = numpy.argmax(logits, axis=-1)
-
         # Convert these IDs back to label strings using vocab
         output_dict["label"] = [
             self.vocab.get_token_from_index(x, namespace="tokens") for x in predicted_id
@@ -144,7 +148,5 @@ class LanguageModel(Model):
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         return {"perplexity": self.metric.get_metric(reset)}
 
-
-if __name__ == "__main__":
-    # all of these experiments are in main now
-    print("Run main.py for model training")
+    def count_parameters(self):
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/src/scripts/train_tokenizer.py
+++ b/src/scripts/train_tokenizer.py
@@ -1,3 +1,5 @@
+import os
+
 from tokenizers import Tokenizer
 from tokenizers.models import BPE, Unigram, WordPiece, WordLevel
 from tokenizers import pre_tokenizers
@@ -5,18 +7,20 @@ from tokenizers import normalizers
 from tokenizers.trainers import BpeTrainer, UnigramTrainer, WordPieceTrainer, WordLevelTrainer
 
 # Local
-import sys; sys.path.append('../')
+import sys;
+
+sys.path.append('../')
 from count import tokenizer, config
 
-def train(
-    algorithm: str = "bpe",
-    files: list = [str(config.WIKI_RAW_DIR / "wiki.train.raw")],
-    output: str = config.TOKENIZER,
-    vocab_size: int = 32_000,
-    pre: list = None,
-    norms: list = None,
-):
 
+def train(
+        algorithm: str = "bpe",
+        files: list = [str(config.WIKI_RAW_DIR / "wiki.train.raw")],
+        output: str = config.TOKENIZER,
+        vocab_size: int = 32_000,
+        pre: list = None,
+        norms: list = None,
+):
     special_tokens = [config.PAD, config.UNK, config.CLS, config.SEP]
     # Initialize the classes
     # ======================
@@ -58,8 +62,8 @@ def train(
 
 if __name__ == "__main__":
     ALGORITHM = "unigram"
-    print(str(config.WIKI_RAW_DIR / "wiki.train.raw"))
-    FILES = [str(config.WIKI_RAW_DIR / "wiki.train.raw")]
+    print(os.path.join(config.WIKI_RAW_DIR, "wiki.train.raw"))
+    FILES = [os.path.join((config.WIKI_RAW_DIR / "wiki.train.raw"))]
     OUTPUT = config.TOKENIZER
     VOCAB_SIZE = 30_000
     PRE_TOKENIZERS = [pre_tokenizers.Whitespace(), pre_tokenizers.ByteLevel()]


### PR DESCRIPTION
1. This PR contains changes to the calculation of perplexity. The normalizer factor in the cross entropy is given by the original number of tokens. This means we need to scale the average cross entropy by the ratio of the original number of tokens by the current number of tokens. 
2. This PR also includes changes to how paths are acessed from `config.py` . The root is cast as a string in the config file. 
We also use `os.path.join` for creating paths.
3. Fixed issue with allen nlp cuda device recognition. 